### PR TITLE
Handle short HEX colors

### DIFF
--- a/src/utils/color_utils.py
+++ b/src/utils/color_utils.py
@@ -1,56 +1,51 @@
-# 'src/utils/color_utils.py'
+"""Utility functions for color manipulation.
+
+Provides functions to adjust color brightness, contrast, and other
+properties. Supports both three- and six-character HEX color strings.
 """
-Utility functions for color manipulation.
-Provides functions to adjust color brightness, contrast, and other properties.
-"""
 
 
-def adjust_color(hex_color, offset=-10):
+def _normalize_hex(hex_color: str) -> str:
+    """Return a normalized 6-character hex string without the leading '#'.
+
+    Accepts either 3- or 6-character hex color strings. A ``ValueError`` is
+    raised if the provided color is of any other length.
     """
-    Adjusts a hex color by adding/subtracting from each RGB component.
 
-    Args:
-        hex_color: Hex color string (e.g. '#4287f5')
-        offset: Amount to adjust RGB values (+/-)
+    hex_color = hex_color.lstrip("#")
+    if len(hex_color) == 3:
+        hex_color = "".join(c * 2 for c in hex_color)
+    elif len(hex_color) != 6:
+        raise ValueError("hex_color must be 3 or 6 hex digits")
+    return hex_color
 
-    Returns:
-        str: New hex color string
-    """
-    hex_color = hex_color.lstrip('#')
 
-    # Parse RGB components
+def adjust_color(hex_color: str, offset: int = -10) -> str:
+    """Adjust a hex color by adding/subtracting from each RGB component."""
+
+    hex_color = _normalize_hex(hex_color)
+
     r = int(hex_color[0:2], 16)
     g = int(hex_color[2:4], 16)
     b = int(hex_color[4:6], 16)
 
-    # Adjust and clamp values
     r_new = max(0, min(255, r + offset))
     g_new = max(0, min(255, g + offset))
     b_new = max(0, min(255, b + offset))
 
-    # Return new hex color
     return f"#{r_new:02X}{g_new:02X}{b_new:02X}"
 
 
-def get_contrasting_text_color(hex_color):
-    """
-    Determines whether white or black text should be used on a given background color.
+def get_contrasting_text_color(hex_color: str) -> str:
+    """Return '#FFFFFF' or '#000000' for readable text on a color."""
 
-    Args:
-        hex_color: Hex color string (e.g. '#4287f5')
+    hex_color = _normalize_hex(hex_color)
 
-    Returns:
-        str: '#FFFFFF' for white or '#000000' for black
-    """
-    hex_color = hex_color.lstrip('#')
-
-    # Parse RGB components
     r = int(hex_color[0:2], 16)
     g = int(hex_color[2:4], 16)
     b = int(hex_color[4:6], 16)
 
-    # Calculate perceived brightness (ITU-R BT.709)
     brightness = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255
 
-    # Use white text on dark backgrounds, black text on light backgrounds
-    return '#FFFFFF' if brightness < 0.5 else '#000000'
+    return "#FFFFFF" if brightness < 0.5 else "#000000"
+


### PR DESCRIPTION
## Summary
- add helper to normalize 3- and 6-digit HEX codes
- avoid crashes when adjusting colors or calculating contrast

## Testing
- `python -m py_compile src/utils/color_utils.py`
- `python - <<'PY'
from src.utils.color_utils import adjust_color, get_contrasting_text_color
print(adjust_color('#fff'))
print(adjust_color('#123456', 20))
print(get_contrasting_text_color('#000'))
print(get_contrasting_text_color('#FFFFFF'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a7862cc1dc832697cce9974b7c95bb